### PR TITLE
Fixing exp timestamp in capability token.

### DIFF
--- a/src/classes/TwilioCapability.cls
+++ b/src/classes/TwilioCapability.cls
@@ -119,7 +119,7 @@ global class TwilioCapability {
 	 * @return the newly generated token that is valid for 3600 seconds
 	 */
 	global String generateToken() {
-		return generateToken(System.currentTimeMillis() + 3600);
+		return generateToken(3600);
 	}
 
 	/**
@@ -137,7 +137,7 @@ global class TwilioCapability {
 		buildOutgoingScope();		
 		Map<String, Object> payload = new Map<String, Object>();
 		payload.put('iss', this.accountSid);
-		payload.put('exp', String.valueOf(System.currentTimeMillis() + ttl));
+		payload.put('exp', String.valueOf(System.currentTimeMillis()/1000 + ttl));
 		payload.put('scope', join(this.scopes, ' '));
 		return jwtEncode(payload, this.authToken);
 	}


### PR DESCRIPTION
Fix for https://github.com/twilio/twilio-salesforce/issues/18

The exp timestamp is expected to be in seconds since Unix epoch, not milliseconds.  Also the default exp needed to be corrected.
