### PR TITLE
use https instead of http for the GET test

### DIFF
--- a/src/classes/Twilio_TestRest.cls
+++ b/src/classes/Twilio_TestRest.cls
@@ -29,7 +29,7 @@ private class Twilio_TestRest {
 	final static String authToken = '12345678901234567890123456789012';
 	
     static testMethod void testTwilioRestResponse() {
-        String url = 'http://api.twilio.com';
+        String url = 'https://api.twilio.com';
         String queryString = 'a=1&b=2';
         String responseText = 'This is a test';
         TwilioRestResponse response = new TwilioRestResponse(url+'?'+queryString,responseText,200);


### PR DESCRIPTION
We should use https://api.twilio.com instead of http://api.twilio.com for the GET tests.
